### PR TITLE
Appiuum Version Minor Update

### DIFF
--- a/src/main/java/com/bottlerocket/webdriverwrapper/AppiumDriverWrapperIos.java
+++ b/src/main/java/com/bottlerocket/webdriverwrapper/AppiumDriverWrapperIos.java
@@ -320,6 +320,11 @@ public class AppiumDriverWrapperIos extends AppiumDriverWrapper {
         driver.activateApp(bundleId);
     }
 
+    public void terminateApp(String bundleId) {
+        driver.terminateApp(bundleId);
+
+    }
+
     @Override
     public void startRecording() {
         driver.startRecordingScreen();

--- a/src/test/java/com/bottlerocket/frameworkTests/TestGetElementBy.java
+++ b/src/test/java/com/bottlerocket/frameworkTests/TestGetElementBy.java
@@ -6,13 +6,16 @@ import com.bottlerocket.webdriverwrapper.ExpectedConditionsWrapper;
 import com.bottlerocket.webdriverwrapper.WebDriverWrapper;
 import io.appium.java_client.AppiumBy;
 import org.openqa.selenium.*;
+import org.openqa.selenium.remote.*;
 import org.openqa.selenium.support.locators.RelativeLocator;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
+import java.io.*;
 import java.util.List;
 
 import static com.bottlerocket.frameworkTests.SauceLabsTestRunner.*;
+import static com.bottlerocket.frameworkTests.TestSwipeMethods.PROJECT_LEVEL_PROPERTY_FILE;
 
 public class TestGetElementBy {
 
@@ -22,10 +25,11 @@ public class TestGetElementBy {
     String sauceLabsURL = "https://your-url";
     SauceLabsTestRunner runner = new SauceLabsTestRunner(sauceUsername, sauceLabsURL);
 
-    private AutomationConfigProperties setupWebTestConfig(String projectName, int buildNumber, String sauceLabsURL, int globalWait) {
+    private AutomationConfigProperties setupWebTestConfig(String projectName, int buildNumber, String sauceLabsURL, int globalWait) throws IOException {
 
         // set up minimal project-level properties
-        AutomationConfigProperties webTestConfig = new AutomationConfigProperties();
+        DesiredCapabilities capabilities = new DesiredCapabilities();
+        AutomationConfigProperties webTestConfig = new AutomationConfigProperties(capabilities, PROJECT_LEVEL_PROPERTY_FILE);
         webTestConfig.projectName = projectName;
         webTestConfig.appiumVersion = "1.22.2";
         webTestConfig.globalWait = globalWait;
@@ -41,7 +45,7 @@ public class TestGetElementBy {
     }
 
     @Test
-    public void testImplicitWaitGetElementByFunctions() {
+    public void testImplicitWaitGetElementByFunctions() throws IOException {
         WebDriverWrapper driverWrapper;
         StringBuilder testResults = new StringBuilder();
 
@@ -117,7 +121,7 @@ public class TestGetElementBy {
     }
 
     @Test
-    public void testExplicitWaitGetElementByFunctions() {
+    public void testExplicitWaitGetElementByFunctions() throws IOException {
         WebDriverWrapper driverWrapper;
         StringBuilder testResults = new StringBuilder();
 
@@ -198,7 +202,7 @@ public class TestGetElementBy {
     }
 
     @Test
-    public void testSelenium4RelativeLocators() {
+    public void testSelenium4RelativeLocators() throws IOException {
         WebDriverWrapper driverWrapper;
         StringBuilder testResults = new StringBuilder();
 
@@ -285,11 +289,12 @@ public class TestGetElementBy {
 
     // TODO: make test using webpage accessibility IDs (such as ARIA)
     @Test(enabled = false)
-    public void testFindByAccessibilityIdOnWeb() {
+    public void testFindByAccessibilityIdOnWeb() throws IOException {
         WebDriverWrapper driverWrapper;
 
         // set up minimal project-level properties
-        AutomationConfigProperties webTestConfig = new AutomationConfigProperties();
+        DesiredCapabilities capabilities = new DesiredCapabilities();
+        AutomationConfigProperties webTestConfig = new AutomationConfigProperties(capabilities, PROJECT_LEVEL_PROPERTY_FILE);
         webTestConfig.projectName = "testAccessibilityIdsOnWeb";
         webTestConfig.appiumVersion = "1.22.2";
         webTestConfig.globalWait = 15;
@@ -320,11 +325,12 @@ public class TestGetElementBy {
 
     // TODO: make test using Android accessibility IDs (such as content-desc)
     @Test(enabled = false)
-    public void testFindByAccessibilityIdOnAndroid() {
+    public void testFindByAccessibilityIdOnAndroid() throws IOException {
         WebDriverWrapper driverWrapper;
 
         // set up minimal project-level properties
-        AutomationConfigProperties androidTestConfig = new AutomationConfigProperties();
+        DesiredCapabilities capabilities = new DesiredCapabilities();
+        AutomationConfigProperties androidTestConfig = new AutomationConfigProperties(capabilities, PROJECT_LEVEL_PROPERTY_FILE);
         androidTestConfig.projectName = "testFindByAccessibilityIdOnAndroid";
         androidTestConfig.appiumVersion = "1.22.2";
         androidTestConfig.globalWait = 15;
@@ -351,11 +357,12 @@ public class TestGetElementBy {
     }
 
     @Test
-    public void testFindByAccessibilityIdOnIos() {
+    public void testFindByAccessibilityIdOnIos() throws IOException {
         WebDriverWrapper driverWrapper;
 
         // set up minimal project-level properties
-        AutomationConfigProperties iosTestConfig = new AutomationConfigProperties();
+        DesiredCapabilities capabilities = new DesiredCapabilities();
+        AutomationConfigProperties iosTestConfig = new AutomationConfigProperties(capabilities, PROJECT_LEVEL_PROPERTY_FILE);
         iosTestConfig.projectName = "testIosAppOnSauceLabs";
         iosTestConfig.appiumVersion = "1.22.2";
         iosTestConfig.globalWait = 15;

--- a/src/test/java/com/bottlerocket/frameworkTests/TestRunOnSauce.java
+++ b/src/test/java/com/bottlerocket/frameworkTests/TestRunOnSauce.java
@@ -11,8 +11,11 @@ import org.openqa.selenium.remote.DesiredCapabilities;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
+import java.io.*;
 import java.util.ArrayList;
 import java.util.List;
+
+import static com.bottlerocket.frameworkTests.TestSwipeMethods.PROJECT_LEVEL_PROPERTY_FILE;
 
 /**
  * Created by ford.arnett on 3/10/23
@@ -32,11 +35,12 @@ public class TestRunOnSauce {
 
 
     @Test
-    public void testWebDriverWrapperRunsOnSauceLabs() {
+    public void testWebDriverWrapperRunsOnSauceLabs() throws IOException {
         WebDriverWrapper driverWrapper;
 
         // set up minimal project-level properties
-        AutomationConfigProperties webTestConfig = new AutomationConfigProperties();
+        DesiredCapabilities capabilities = new DesiredCapabilities();
+        AutomationConfigProperties webTestConfig = new AutomationConfigProperties(capabilities, PROJECT_LEVEL_PROPERTY_FILE);
         webTestConfig.projectName = "testWebpageOnSauceLabs";
         webTestConfig.appiumVersion = "1.22.2";
         webTestConfig.globalWait = 15;
@@ -64,11 +68,12 @@ public class TestRunOnSauce {
     }
 
     @Test
-    public void testAndroidAppOnSauce() {
+    public void testAndroidAppOnSauce() throws IOException {
         WebDriverWrapper driverWrapper;
 
         // set up minimal project-level properties
-        AutomationConfigProperties androidTestConfig = new AutomationConfigProperties();
+        DesiredCapabilities capabilities = new DesiredCapabilities();
+        AutomationConfigProperties androidTestConfig = new AutomationConfigProperties(capabilities, PROJECT_LEVEL_PROPERTY_FILE);
         androidTestConfig.projectName = "testAndroidAppOnSauceLabs";
         androidTestConfig.appiumVersion = "1.22.2";
         androidTestConfig.globalWait = 15;
@@ -93,11 +98,12 @@ public class TestRunOnSauce {
     }
 
     @Test
-    public void testMultiAndroidAppOnSauce() {
+    public void testMultiAndroidAppOnSauce() throws IOException {
         WebDriverWrapper driverWrapper;
 
         // set up minimal project-level properties
-        AutomationConfigProperties androidTestConfig = new AutomationConfigProperties();
+        DesiredCapabilities capabilities = new DesiredCapabilities();
+        AutomationConfigProperties androidTestConfig = new AutomationConfigProperties(capabilities, PROJECT_LEVEL_PROPERTY_FILE);
         androidTestConfig.projectName = "testAndroidAppOnSauceLabs";
         androidTestConfig.appiumVersion = "1.22.2";
         androidTestConfig.globalWait = 15;
@@ -124,11 +130,13 @@ public class TestRunOnSauce {
     }
 
     @Test
-    public void testIosAppOnSauce() {
+    public void testIosAppOnSauce() throws IOException {
         WebDriverWrapper driverWrapper;
 
         // set up minimal project-level properties
-        AutomationConfigProperties iosTestConfig = new AutomationConfigProperties();
+        DesiredCapabilities capabilities = new DesiredCapabilities();
+        AutomationConfigProperties iosTestConfig = new AutomationConfigProperties(capabilities, PROJECT_LEVEL_PROPERTY_FILE);
+
         iosTestConfig.projectName = "testIosAppOnSauceLabs";
         iosTestConfig.appiumVersion = "1.22.2";
         iosTestConfig.globalWait = 15;

--- a/src/test/java/com/bottlerocket/frameworkTests/TestSwipeMethods.java
+++ b/src/test/java/com/bottlerocket/frameworkTests/TestSwipeMethods.java
@@ -5,15 +5,20 @@ import com.bottlerocket.utils.WebElementUtils;
 import com.bottlerocket.webdriverwrapper.AppiumDriverWrapper;
 import com.bottlerocket.utils.SwipeUtils;
 import org.openqa.selenium.*;
+import org.openqa.selenium.remote.*;
 import org.testng.Assert;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
+import java.io.*;
+
+import static com.bottlerocket.config.AutomationConfigPropertiesLoader.PROPERTIES_DIRECTORY;
 import static com.bottlerocket.frameworkTests.SauceLabsTestRunner.*;
 
 public class TestSwipeMethods {
     AppiumDriverWrapper driverWrapper;
+    public static final String PROJECT_LEVEL_PROPERTY_FILE = PROPERTIES_DIRECTORY + "app-config.properties";
 
     @BeforeMethod(onlyForGroups = {"testSwipe"})
     public void setup() {
@@ -35,7 +40,7 @@ public class TestSwipeMethods {
     SauceLabsTestRunner runner = new SauceLabsTestRunner(sauceUsername, sauceLabsOnDemandUrl);
 
     @Test(groups = {"testSwipe"})
-    public void testBRFrameworkSwipeAndroid() {
+    public void testBRFrameworkSwipeAndroid() throws IOException {
 
 //        Appium emulator capabilities downloaded from SauceLabs platform configurator
 //        {
@@ -70,8 +75,9 @@ public class TestSwipeMethods {
 //        URL url = new URL("https://ondemand.us-west-1.saucelabs.com:443/wd/hub");
 //        AndroidDriver driver = new AndroidDriver(url, caps);
 
+        DesiredCapabilities capabilities = new DesiredCapabilities();
         // set up minimal project-level properties
-        AutomationConfigProperties androidTestConfig = new AutomationConfigProperties();
+        AutomationConfigProperties androidTestConfig = new AutomationConfigProperties(capabilities, PROJECT_LEVEL_PROPERTY_FILE);
         androidTestConfig.projectName = "testBRFrameworkTapAndSwipeAndroid";
         androidTestConfig.appiumVersion = "1.22.3";
         androidTestConfig.globalWait = 15;
@@ -142,7 +148,7 @@ public class TestSwipeMethods {
     }
 
     @Test
-    public void testBRFrameworkSwipeIos() {
+    public void testBRFrameworkSwipeIos() throws IOException {
 
         // Appium iOS simulator capabilities downloaded from SauceLabs platform configurator
 //        MutableCapabilities caps = new MutableCapabilities();
@@ -161,7 +167,9 @@ public class TestSwipeMethods {
 //        IOSDriver driver = new IOSDriver(url, caps);
 
         // set up minimal project-level properties
-        AutomationConfigProperties iosTestConfig = new AutomationConfigProperties();
+        DesiredCapabilities capabilities = new DesiredCapabilities();
+        // set up minimal project-level properties
+        AutomationConfigProperties iosTestConfig = new AutomationConfigProperties(capabilities, PROJECT_LEVEL_PROPERTY_FILE);
         iosTestConfig.projectName = "testBRFrameworkTapAndSwipeIos";
         iosTestConfig.appiumVersion = "1.22.3";
         iosTestConfig.globalWait = 15;


### PR DESCRIPTION
* update to appium version 2.1.3
* add methods for newer versions of appium to close and open app for ios
  - terminateApp(bundleId)
  - activateApp(bundleId)
* Update test methods to use new AutomationConfigProperties constructor that was updated in the first framework version 3.2.1